### PR TITLE
Add functionality for classification types

### DIFF
--- a/annotationweb/forms.py
+++ b/annotationweb/forms.py
@@ -10,8 +10,12 @@ class ImportLocalDatasetForm(forms.Form):
 class TaskForm(forms.ModelForm):
     class Meta:
         model = Task
-        fields = ['name', 'dataset', 'show_entire_sequence', 'frames_before',
-                  'frames_after', 'auto_play', 'user_frame_selection', 'annotate_single_frame', 'shuffle_videos', 'type', 'label', 'user', 'description']
+        fields = ['name', 'dataset', 'type',
+                  'classification_type',
+                  'show_entire_sequence', 'frames_before', 'frames_after', 'auto_play',
+                  'user_frame_selection', 'annotate_single_frame', 'shuffle_videos',
+                  'label', 'user', 'description']
+
 
     # def clean(self):
     #     cleaned_data = super(TaskForm, self).clean()

--- a/annotationweb/forms.py
+++ b/annotationweb/forms.py
@@ -1,4 +1,6 @@
 from django import forms
+from django.core.exceptions import ValidationError
+
 from .models import *
 
 
@@ -16,11 +18,37 @@ class TaskForm(forms.ModelForm):
                   'user_frame_selection', 'annotate_single_frame', 'shuffle_videos',
                   'label', 'user', 'description']
 
+    def clean_classification_type(self):
+        data = self.cleaned_data['classification_type']
+        if self.cleaned_data['type'] == 'classification':
+            if data == '':
+                raise ValidationError(
+                    "You chose the task type classification, but have forgotten to choose classification type",
+                    code='invalid'
+                )
+            else:
+                pass
+        else:
+            data = None
 
-    # def clean(self):
-    #     cleaned_data = super(TaskForm, self).clean()
+        # Always return a value to use as the new cleaned data, even if
+        # this method didn't change it.
+        return data
+
+    def clean(self):
+        cleaned_data = super(TaskForm, self).clean()
     #     user_frame_selection = cleaned_data.get('user_frame_selection')
     #     annotate_single_frame = cleaned_data.get('annotate_single_frame')
+
+        task_type = cleaned_data.get('type')
+        classification_type = cleaned_data.get('classification_type')
+
+        if task_type == 'classification':
+            if classification_type == '':
+                raise ValidationError(
+                    "No classification type was chosen, but task type is Classification",
+                    code='invalid'
+                )
 
 
 class DatasetForm(forms.ModelForm):

--- a/annotationweb/models.py
+++ b/annotationweb/models.py
@@ -61,6 +61,15 @@ class Task(models.Model):
         (CALIPER, 'Caliper'),
     )
 
+    CLASSIFICATION_WHOLE_SEQUENCE = 'whole_sequence'
+    CLASSIFICATION_SINGLE_FRAME = 'single_frame'
+    # CLASSIFICATION_SUBSEQUENCE = 'subsequence'
+    CLASSIFICATION_TYPES = (
+        (CLASSIFICATION_WHOLE_SEQUENCE, 'Whole sequence'),
+        (CLASSIFICATION_SINGLE_FRAME, 'Single frame'),
+        # (CLASSIFICATION_SUBSEQUENCE, 'Subsequence'),
+    )
+
     name = models.CharField(max_length=200)
     dataset = models.ManyToManyField(Dataset)
     show_entire_sequence = models.BooleanField(help_text='Allow user to see entire sequence.', default=False)
@@ -80,6 +89,8 @@ class Task(models.Model):
     large_image_layout = models.BooleanField(default=False, help_text='Use a large image layout for annotation')
     post_processing_method = models.CharField(default='', help_text='Name of post processing method to use', max_length=255, blank=True)
 
+    classification_type = models.CharField(max_length=50, blank=True, choices=CLASSIFICATION_TYPES)
+
     def __str__(self):
         return self.name
 
@@ -92,7 +103,14 @@ class Task(models.Model):
             return ImageSequence.objects.filter(subject__dataset__task=self).count()
         else:
             # TODO: Fix - annotated/total frames not correctly estimated for classification without user_frame_selection!!
-            return ImageSequence.objects.filter(imageannotation__task=self).count()
+            if (self.type == Task.CLASSIFICATION
+                and (self.classification_type == Task.CLASSIFICATION_WHOLE_SEQUENCE
+                     # or self.classification_type == Task.CLASSIFICATION_SUBSEQUENCE
+                     or (self.classification_type == Task.CLASSIFICATION_SINGLE_FRAME and not self.user_frame_selection))
+            ):
+                return ImageSequence.objects.filter(subject__dataset__task=self).count()    #ImageSequence.objects.filter(imageannotation__task=self).count()
+            else:
+                return ImageSequence.objects.filter(imageannotation__task=self).count()
 
     @property
     def number_of_annotated_images(self):
@@ -105,6 +123,14 @@ class Task(models.Model):
         else:
             return round(self.number_of_annotated_images*100 / self.total_number_of_images, 1)
 
+    def user_frame_selection_valid(self):
+        if (self.type == Task.CLASSIFICATION
+            and (self.classification_type == Task.CLASSIFICATION_WHOLE_SEQUENCE
+                 # or self.classification_type == Task.CLASSIFICATION_SUBSEQUENCE
+                )):
+            return False
+
+        return True
 
 
 class ImageSequence(models.Model):

--- a/annotationweb/models.py
+++ b/annotationweb/models.py
@@ -99,18 +99,16 @@ class Task(models.Model):
 
     @property
     def total_number_of_images(self):
-        if self.user_frame_selection:
+        if self.user_frame_selection_valid():
+            return ImageSequence.objects.filter(subject__dataset__task=self).count()
+        elif (self.type == Task.CLASSIFICATION
+              and (self.classification_type == Task.CLASSIFICATION_WHOLE_SEQUENCE
+                   # or self.classification_type == Task.CLASSIFICATION_SUBSEQUENCE
+                   or (self.classification_type == Task.CLASSIFICATION_SINGLE_FRAME and not self.user_frame_selection))
+              ):
             return ImageSequence.objects.filter(subject__dataset__task=self).count()
         else:
-            # TODO: Fix - annotated/total frames not correctly estimated for classification without user_frame_selection!!
-            if (self.type == Task.CLASSIFICATION
-                and (self.classification_type == Task.CLASSIFICATION_WHOLE_SEQUENCE
-                     # or self.classification_type == Task.CLASSIFICATION_SUBSEQUENCE
-                     or (self.classification_type == Task.CLASSIFICATION_SINGLE_FRAME and not self.user_frame_selection))
-            ):
-                return ImageSequence.objects.filter(subject__dataset__task=self).count()    #ImageSequence.objects.filter(imageannotation__task=self).count()
-            else:
-                return ImageSequence.objects.filter(imageannotation__task=self).count()
+            return ImageSequence.objects.filter(imageannotation__task=self).count()
 
     @property
     def number_of_annotated_images(self):
@@ -127,7 +125,7 @@ class Task(models.Model):
         if (self.type == Task.CLASSIFICATION
             and (self.classification_type == Task.CLASSIFICATION_WHOLE_SEQUENCE
                  # or self.classification_type == Task.CLASSIFICATION_SUBSEQUENCE
-                )):
+                 )):
             return False
 
         return True

--- a/annotationweb/models.py
+++ b/annotationweb/models.py
@@ -91,6 +91,7 @@ class Task(models.Model):
         if self.user_frame_selection:
             return ImageSequence.objects.filter(subject__dataset__task=self).count()
         else:
+            # TODO: Fix - annotated/total frames not correctly estimated for classification without user_frame_selection!!
             return ImageSequence.objects.filter(imageannotation__task=self).count()
 
     @property

--- a/annotationweb/templates/annotationweb/index_admin.html
+++ b/annotationweb/templates/annotationweb/index_admin.html
@@ -27,7 +27,11 @@
     {% for task in tasks %}
     <tr>
         <td>{{ task.name }}</td>
-        <td align="center">{{ task.type }}</td>
+        {% if task.type == 'classification' %}
+            <td align="center">{{ task.type }} ({{ task.classification_type.capitalize }})</td>
+        {% else %}
+            <td align="center">{{ task.type }}</td>
+        {% endif %}
         <td align="center">{{task.total_number_of_images}}</td>
         <td align="center">{{task.percentage_finished}}%</td>
         <td align="center"><a href="{% url 'task' task.id %}">Image list</a></td>

--- a/annotationweb/templates/annotationweb/index_annotater.html
+++ b/annotationweb/templates/annotationweb/index_annotater.html
@@ -23,7 +23,11 @@
     {% for task in tasks %}
     <tr>
         <td>{{ task.name }}</td>
-        <td align="center">{{ task.type }}</td>
+        {% if task.type == 'classification' %}
+            <td align="center">{{ task.type }} ({{ task.classification_type.capitalize }})</td>
+        {% else %}
+            <td align="center">{{ task.type }}</td>
+        {% endif %}
         <td align="center">{{task.total_number_of_images}}</td>
         <td align="center">{{task.percentage_finished}}%</td>
         <td align="center"><a href="{% url 'task' task.id %}">Image list</a></td>

--- a/annotationweb/templates/annotationweb/new_task.html
+++ b/annotationweb/templates/annotationweb/new_task.html
@@ -27,36 +27,58 @@ $(window).blur(function() {
 </form>
 
 <script>
-    function set_classification_type_enabled() {
-        let classification_type_input = $("#id_classification_type");
-        classification_type_input.prop('disabled', false);
-
+    function enable_field(field_id) {
+        let input = $("#" + field_id);
+        input.prop('disabled', false);
         // Format label
-        let label = $('label[for="' + classification_type_input.selector.slice(1) + '"]')[0];
+        let label = $('label[for="' + input.selector.slice(1) + '"]')[0];
         label.style.color = "#000000";
     }
 
-    function set_classification_type_disabled() {
-        let classification_type_input = $("#id_classification_type");
-        classification_type_input.prop('disabled', true);
+    function disable_field(field_id) {
+        let input = $("#" + field_id);
+        input.prop('disabled', true);
         // Format label
-        let label = $('label[for="' + classification_type_input.selector.slice(1) + '"]')[0];
+        let label = $('label[for="' + input.selector.slice(1) + '"]')[0];
         label.style.color = "#aaaaaa";
     }
 
     $(document).ready(function(e) {
-        set_classification_type_disabled();
+        if ($("#id_type").val() === 'classification') {
+            enable_field("id_classification_type");
+            disable_field("id_annotate_single_frame");
+        } else {
+            disable_field("id_classification_type");
+        }
     })
 
     $("#id_type").change(function () {
         let taskType = $(this).val();  // get the selected task type from the HTML input
         if (taskType === 'classification') {
-            set_classification_type_enabled();
+            enable_field("id_classification_type");
+            disable_field("id_annotate_single_frame");
         } else {
             // Reset classification_type choice to default value
             $('select[name="classification_type"] option').attr("selected", false);
             $('select[name="classification_type"] option[value=""]').attr("selected", true);
-            set_classification_type_disabled();
+            disable_field("id_classification_type");
+            enable_field("id_annotate_single_frame");
+        }
+    });
+
+    $("#id_classification_type").change(function () {
+        // This field is only enabled and can change when task type is set to 'classification'
+        let classificationType = $(this).val();
+
+        if (classificationType === 'whole_sequence') {
+            disable_field("id_user_frame_selection");
+            disable_field("id_annotate_single_frame");
+        } else if (classificationType === 'single_frame') {
+            enable_field("id_user_frame_selection");
+            disable_field("id_annotate_single_frame");
+        } else {
+            disable_field("id_user_frame_selection");
+            //enable_field("id_annotate_single_frame");
         }
     });
 </script>

--- a/annotationweb/templates/annotationweb/new_task.html
+++ b/annotationweb/templates/annotationweb/new_task.html
@@ -25,4 +25,40 @@ $(window).blur(function() {
     </table>
     <input type="submit" value="Submit" />
 </form>
+
+<script>
+    function set_classification_type_enabled() {
+        let classification_type_input = $("#id_classification_type");
+        classification_type_input.prop('disabled', false);
+
+        // Format label
+        let label = $('label[for="' + classification_type_input.selector.slice(1) + '"]')[0];
+        label.style.color = "#000000";
+    }
+
+    function set_classification_type_disabled() {
+        let classification_type_input = $("#id_classification_type");
+        classification_type_input.prop('disabled', true);
+        // Format label
+        let label = $('label[for="' + classification_type_input.selector.slice(1) + '"]')[0];
+        label.style.color = "#aaaaaa";
+    }
+
+    $(document).ready(function(e) {
+        set_classification_type_disabled();
+    })
+
+    $("#id_type").change(function () {
+        let taskType = $(this).val();  // get the selected task type from the HTML input
+        if (taskType === 'classification') {
+            set_classification_type_enabled();
+        } else {
+            // Reset classification_type choice to default value
+            $('select[name="classification_type"] option').attr("selected", false);
+            $('select[name="classification_type"] option[value=""]').attr("selected", true);
+            set_classification_type_disabled();
+        }
+    });
+</script>
+
 {% endblock %}

--- a/annotationweb/views.py
+++ b/annotationweb/views.py
@@ -554,7 +554,7 @@ def task(request, task_id):
                 imageannotation__task=task,
                 imageannotation__finished=True,
                 imageannotation__user__in=users_selected,
-                imageannotation__keyframeannotation__imagelabel__in=labels_selected,
+                imageannotation__keyframeannotation__imagelabel__label__in=labels_selected,
                 subject__in=subjects_selected,
             )
         else:

--- a/classification/static/classification/classification.js
+++ b/classification/static/classification/classification.js
@@ -46,3 +46,309 @@ function loadClassificationTask() {
         });
     }
 }
+
+
+function loadClassificationSequence(
+    image_sequence_id, start_frame, nrOfFrames, show_entire_sequence,
+    user_frame_selection, annotate_single_frame, frames_to_annotate,
+    images_to_load_before, images_to_load_after, auto_play, classification_type
+        ){
+    /*
+    This function overloads the loadSequence() function in annotationweb.js and
+    is used for the classification tasks
+
+    Changes
+    -------
+    - Introduce three types of classification that are set with the parameter
+        `classification_type`. These are introduced below.
+    - Subsequently remove the `annotate_single_frame` parameter since this is
+        no longer relevant.
+    - Adapt and redefine the parameter `user_frame_selection` to be suitable for
+        each of the three types of classification tasks.
+
+    Classification types
+    --------------------
+    (1) Single-frame classification: **Not implemented**
+        The admin or the user themselves (if `user_frame_selection`is set)
+        selects single keyframes to be annotated. Each of these keyframes
+        receive an individual label.
+        - `user_frame_selection`: Determines whether admin or user selects frames
+        - `annotate_single_frame`: Irrelevant if `classification_type` introduced
+
+    (2) Whole sequence classification:
+        The whole sequence is classified with the same label. No keyframes are
+        selected by admins or users. Instead, the last frame in the sequence is
+        assigned as a keyframe to store the label for the sequence.
+        For this type of classification, one should probably suggest to use
+        `Reject` if the sequence contains multiple classes.
+        - `user_frame_selection`: Irrelevant. Subsequences are selected by the user
+        - `annotate_single_frame`: Irrelevant if `classification_type` introduced
+
+    (3) Subsequence classification: **Not implemented**
+        Subsequences (parts of a whole sequence) can be classified with
+        different labels.
+        - `user_frame_selection`: Irrelevant. Subsequences are selected by the user
+        - `annotate_single_frame`: Irrelevant if `classification_type` introduced
+
+     */
+
+    console.log('Classification type chosen: ' + classification_type);
+    console.log('User frame selection: ' + user_frame_selection);
+    if (classification_type === 'single_frame') {
+        if (!user_frame_selection && frames_to_annotate.length === 0) {
+            // Admin set to select keyframes, but has selected none --> Give error message??
+        } else {
+            // frames_to_annotate will be used to set keyframes later in the function
+        }
+
+    } else if (classification_type === 'whole_sequence') {
+        // Select last frame as target frame
+        frames_to_annotate.push(nrOfFrames - 1);
+        // user_frame_selection = false;
+    } else if (classification_type === 'subsequence') {
+        // User frame selection is irrelevant for whole-sequence classification
+        // Currently not implemented, so should not have the option to choose this classification type
+    } else {
+        console.log('wrong classification type indicated');
+    }
+
+
+    // If user cannot select frame, and there are no target frames, select last frame as target frame
+    // if (!user_frame_selection && annotate_single_frame && frames_to_annotate.length === 0) {
+    //     // Select last frame as target frame
+    //     frames_to_annotate.push(nrOfFrames - 1);
+    // }
+    g_userFrameSelection = user_frame_selection;
+
+    // Check for ECG
+    $.get('/ecg/' + image_sequence_id + '/', function (data, status) {
+        if (data !== 'NO') {
+            g_ecgData = data['ecg'];
+            g_ecgMin = Number.MAX_VALUE;
+            g_ecgMax = -Number.MAX_VALUE;
+            for (let i = 0; i < g_ecgData.length; ++i) {
+                if (g_ecgData[i]['value'] < g_ecgMin)
+                    g_ecgMin = g_ecgData[i]['value'];
+                if (g_ecgData[i]['value'] > g_ecgMax)
+                    g_ecgMax = g_ecgData[i]['value'];
+            }
+
+            // Create ECG plot
+            // Create canvas
+            var sequenceDiv = document.getElementById('slider');
+            var canvas = document.createElement('canvas');
+            sequenceDiv.before(canvas);
+            let canvasHeight = 100;
+            canvas.setAttribute('width', $('#contentLeft').width());
+            canvas.setAttribute('height', canvasHeight);
+            canvas.setAttribute('id', 'ecgCanvas');
+            canvas.setAttribute('style', 'width: 100%; height: ' + canvasHeight + 'px;');
+            // IE stuff
+            if (typeof G_vmlCanvasManager != 'undefined') {
+                canvas = G_vmlCanvasManager.initElement(canvas);
+            }
+            g_ecgContext = canvas.getContext("2d");
+
+            drawECG();
+        }
+    });
+
+    console.log('In load sequence');
+    // Create play/pause button
+    setPlayButton(auto_play);
+    $("#playButton").click(function () {
+        setPlayButton(!g_isPlaying);
+        if (g_isPlaying) // Start it again
+            incrementFrame();
+    });
+
+    // Create canvas
+    var canvas = document.getElementById('canvas');
+    canvas.setAttribute('width', g_canvasWidth);
+    canvas.setAttribute('height', g_canvasHeight);
+    // IE stuff
+    if (typeof G_vmlCanvasManager != 'undefined') {
+        canvas = G_vmlCanvasManager.initElement(canvas);
+    }
+    g_context = canvas.getContext("2d");
+
+    if (g_targetFrames.length > 0) {
+        g_currentFrameNr = g_targetFrames[0];
+    } else {
+        g_currentFrameNr = 0;
+    }
+
+    var start;
+    var end;
+    var totalToLoad;
+    if (show_entire_sequence || !annotate_single_frame) {
+        start = start_frame;
+        end = start_frame + nrOfFrames - 1;
+        totalToLoad = nrOfFrames;
+    } else {
+        start = max(start_frame, g_currentFrameNr - images_to_load_before);
+        end = min(start_frame + nrOfFrames - 1, g_currentFrameNr + images_to_load_after);
+        totalToLoad = end - start;
+    }
+    g_startFrame = start;
+    g_sequenceLength = end - start;
+
+    // Create slider
+    $("#slider").slider(
+        {
+            range: "max",
+            min: start,
+            max: end,
+            step: 1,
+            value: g_currentFrameNr,
+            slide: function (event, ui) {
+                goToFrame(ui.value);
+            }
+        }
+    );
+
+    // Create progress bar
+    g_progressbar = $("#progressbar");
+    var progressLabel = $(".progress-label");
+    g_progressbar.progressbar({
+        value: false,
+        change: function () {
+            progressLabel.text("Please wait while loading. " + g_progressbar.progressbar("value").toFixed(1) + "%");
+        },
+        complete: function () {
+            // Remove progress bar and redraw
+            progressLabel.text("Finished loading!");
+            g_progressbar.hide();
+            redrawSequence();
+            g_progressbar.trigger('markercomplete');
+            if (g_isPlaying)
+                incrementFrame();
+        }
+    });
+
+    for (var i = 0; i < frames_to_annotate.length; ++i) {
+        addKeyFrame(frames_to_annotate[i]);
+        if (classification_type === 'whole_sequence') {
+            // don't show slider mark
+            $('#sliderMarker' + frames_to_annotate[i]).remove();
+        }
+    }
+
+
+    $("#addFrameButton").click(function () {
+        setPlayButton(false);
+        addKeyFrame(g_currentFrameNr);
+        g_currentTargetFrameIndex = g_targetFrames.length - 1;
+    });
+
+    $("#removeFrameButton").click(function () {
+        setPlayButton(false);
+        if (g_targetFrames.includes(g_currentFrameNr)) {
+            g_targetFrames.splice(g_targetFrames.indexOf(g_currentFrameNr), 1);
+            g_currentTargetFrameIndex = -1;
+            $('#sliderMarker' + g_currentFrameNr).remove();
+            $('#selectedFrames' + g_currentFrameNr).remove();
+            $('#selectedFramesForm' + g_currentFrameNr).remove();
+        }
+    });
+
+    $("#nextFrameButton").click(function () {
+        goToNextKeyFrame();
+    });
+
+    // Moving between frames
+    // Scrolling (mouse must be over canvas)
+    $("#canvas").bind('mousewheel DOMMouseScroll', function (event) {
+        g_shiftKeyPressed = event.shiftKey;
+        console.log('Mousewheel event!');
+        if (event.originalEvent.wheelDelta > 0 || event.originalEvent.detail < 0) {
+            // scroll up
+            if (g_shiftKeyPressed) {
+                goToNextKeyFrame();
+            } else {
+                goToFrame(g_currentFrameNr + 1);
+            }
+        } else {
+            // scroll down
+            if (g_shiftKeyPressed) {
+                goToPreviousKeyFrame();
+            } else {
+                goToFrame(g_currentFrameNr - 1);
+            }
+        }
+        event.preventDefault();
+    });
+
+    $(document).keydown(function (e) {
+        console.log(String.fromCharCode(e.which));
+        if (String.fromCharCode(e.which) == 'Z') {
+            g_zoom = true;
+        }
+    });
+    $(document).keyup(function (e) {
+        console.log('up', String.fromCharCode(e.which));
+        if (String.fromCharCode(e.which) == 'Z') {
+            g_zoom = false;
+        }
+    });
+
+    $('#canvas').mousemove(function (e) {
+        var scale = g_canvasWidth / $('#canvas').width();
+        var mouseX = (e.pageX - this.offsetLeft) * scale;
+        var mouseY = (e.pageY - this.offsetTop) * scale;
+
+        g_mousePositionX = mouseX;
+        g_mousePositionY = mouseY;
+    });
+
+    // Arrow key pressed
+    $(document).keydown(function (event) {
+        g_shiftKeyPressed = event.shiftKey;
+        if (event.which === 37) { // Left
+            if (g_shiftKeyPressed) {
+                goToPreviousKeyFrame();
+            } else {
+                goToFrame(g_currentFrameNr - 1);
+            }
+        } else if (event.which === 39) { // Right
+            if (g_shiftKeyPressed) {
+                goToNextKeyFrame();
+            } else {
+                goToFrame(g_currentFrameNr + 1);
+            }
+        } else if (event.which === 32) { // Space
+            if ($("textarea").is(":focus")) {
+                // Input and text area has focus, do nothing
+            } else {
+                setPlayButton(!g_isPlaying);
+                incrementFrame();
+                event.preventDefault();
+            }
+        }
+    });
+
+    $(document).keyup(function (event) {
+        g_shiftKeyPressed = event.shiftKey;
+    });
+
+
+    // Load images
+    g_framesLoaded = 0;
+    //console.log('start: ' + start + ' end: ' + end)
+    //console.log('target_frame: ' + target_frame)
+    for (var i = start; i <= end; i++) {
+        var image = new Image();
+        image.src = '/show_frame/' + image_sequence_id + '/' + i + '/' + g_taskID + '/';
+        image.onload = function () {
+            g_canvasWidth = this.width;
+            g_canvasHeight = this.height;
+            canvas.setAttribute('width', g_canvasWidth);
+            canvas.setAttribute('height', g_canvasHeight);
+
+            // Update progressbar
+            g_framesLoaded++;
+            g_progressbar.progressbar("value", g_framesLoaded * 100 / totalToLoad);
+        };
+        g_sequence.push(image);
+    }
+}

--- a/classification/templates/classification/label_image.html
+++ b/classification/templates/classification/label_image.html
@@ -13,7 +13,6 @@ loadClassificationSequence(
     {%  if task.show_entire_sequence %}true{% else %}false{% endif %},
     {%  if task.user_frame_selection %}true{% else %}false{% endif %},
     {%  if task.annotate_single_frame %}true{% else %}false{% endif %},
-    <!-- TODO: If classification of whole sequence, add last frame as keyframe by default? -->
     [ {% for frame_nr in frames %}{{ frame_nr }},{% endfor %}],
     {{ task.frames_before }},
     {{ task.frames_after }},

--- a/classification/templates/classification/label_image.html
+++ b/classification/templates/classification/label_image.html
@@ -62,11 +62,13 @@ setReturnURL('{{ return_url|safe }}');
 <div id="slider"></div>
 <div class="actionButtons">
     <button id="playButton" type="button"><i id="play" class="fa fa-play"></i></button>
-    {% if task.user_frame_selection %}
-        <button id="addFrameButton" type="button" title="Select frame for annotation"><i class="fa fa-plus"></i></button>
-        <button id="removeFrameButton" type="button" title="Remove selected frame from annotations"><i class="fa fa-minus"></i></button>
+    {% if classification_type != 'whole_sequence' %}
+        {% if task.user_frame_selection %}
+            <button id="addFrameButton" type="button" title="Select frame for annotation"><i class="fa fa-plus"></i></button>
+            <button id="removeFrameButton" type="button" title="Remove selected frame from annotations"><i class="fa fa-minus"></i></button>
+        {% endif %}
+        <button id="nextFrameButton" type="button" title="Next annotation frame"><i class="fa fa-step-forward"></i></button>
     {% endif %}
-    <button id="nextFrameButton" type="button" title="Next annotation frame"><i class="fa fa-step-forward"></i></button>
 </div>
 {% endif %}
 <h3>Actions</h3>

--- a/classification/templates/classification/label_image.html
+++ b/classification/templates/classification/label_image.html
@@ -1,4 +1,31 @@
-{% extends 'annotationweb/do_task.html' %}
+{% extends 'annotationweb/two_column_layout.html' %}
+
+
+{% block javascript %}
+
+initializeAnnotation({{ task.id }}, {{ image.id }});
+
+{% if image_sequence %}
+loadClassificationSequence(
+    {{ image_sequence.id }},
+    {{ image_sequence.start_frame_nr }},
+    {{ image_sequence.nr_of_frames }},
+    {%  if task.show_entire_sequence %}true{% else %}false{% endif %},
+    {%  if task.user_frame_selection %}true{% else %}false{% endif %},
+    {%  if task.annotate_single_frame %}true{% else %}false{% endif %},
+    <!-- TODO: If classification of whole sequence, add last frame as keyframe by default? -->
+    [ {% for frame_nr in frames %}{{ frame_nr }},{% endfor %}],
+    {{ task.frames_before }},
+    {{ task.frames_after }},
+    {% if task.auto_play %}true{% else %}false{% endif %},
+    "{{ classification_type }}"
+);
+{% endif %}
+
+{# Add label buttons #}
+{% for label in labels %}
+    addLabelButton({{ label.id }}, {{ label.color_red }}, {{ label.color_green }}, {{ label.color_blue }}, {% if label.parent %}{{ label.parent.id }}{% else  %}0{% endif %});
+{% endfor %}
 
 {% block task_javascript %}
 
@@ -7,4 +34,139 @@ loadClassificationTask();
 {% if chosen_label %}
 changeLabel({{ chosen_label }});
 {% endif %}
-{% endblock task_javascript %}
+
+{% endblock %}
+
+{% if return_url %}
+setReturnURL('{{ return_url|safe }}');
+{% endif %}
+
+{% endblock javascript %}
+
+
+{% block content_left %}
+
+{% for message in messages %}
+<div{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</div>
+{% endfor %}
+<div id="message"></div>
+
+<h2>{{ task.name }}</h2>
+
+{{ task.number_of_annotated_images }} of {{ task.total_number_of_images}} videos/images have been labeled ({{ task.percentage_finished }}%)
+
+{% if image_sequence %}
+<h3>Sequence</h3>
+<div id="progressbar"><div class="progress-label">Loading...</div></div>
+<div id="sliderText">Drag the slider to view the other frames in the sequence. Current frame <span id="currentFrame"></span></div>
+<div id="slider"></div>
+<div class="actionButtons">
+    <button id="playButton" type="button"><i id="play" class="fa fa-play"></i></button>
+    {% if task.user_frame_selection %}
+        <button id="addFrameButton" type="button" title="Select frame for annotation"><i class="fa fa-plus"></i></button>
+        <button id="removeFrameButton" type="button" title="Remove selected frame from annotations"><i class="fa fa-minus"></i></button>
+    {% endif %}
+    <button id="nextFrameButton" type="button" title="Next annotation frame"><i class="fa fa-step-forward"></i></button>
+</div>
+{% endif %}
+<h3>Actions</h3>
+<div class="actionButtons">
+    {% if previous_image_id %}
+    <button onclick="javascript:changeImage('{% url 'annotate' task.id previous_image_id %}?{{ request.GET.urlencode }}');">Previous</button>
+    {% endif %}
+    {% if next_image_id %}
+    <button onclick="javascript:changeImage('{% url 'annotate' task.id next_image_id %}?{{ request.GET.urlencode }}');">Next</button>
+    {% endif %}
+    <button id="clearButton" title="Clear">Clear</button>
+    <button id="rejectButton" alt="By rejecting this image, it is removed from the dataset. You may write a comment below of why it was rejected." title="Save as rejected">Reject</button>
+    <button id="saveButton" title="Save">Save</button>
+    <button id="imageListButton" onclick="javascript:window.location.href='{% url 'task' task.id %}'" title="Image list">List</button>
+</div>
+<div id="dialogConfirm">
+    You have done changes to the annotation. <br>
+    Do you wish to save the changes before going to the next/previous image?
+</div>
+<h3>Annotation</h3>
+<div id="imageQuality">
+<form id="imageQualityForm">
+    Image quality:
+    {% for quality_id, quality_name in image_quality_choices %}
+    <input type="radio" name="quality" value="{{ quality_id }}" required{% if chosen_quality == quality_id %} checked="checked"{% endif %}> {{ quality_name }}
+    {% endfor %}
+</form>
+</div>
+
+<div id="labelButtons">
+{% block label_buttons %}
+<div class="flexButtons">
+    {% for label in toplabels %}
+        <button onclick="changeLabel({{ label.id }})" class="labelButton" id="labelButton{{ label.id }}">{{ label.name }}</button>
+    {% endfor %}
+</div>
+{% for sublabel in sublabels %}
+    <div id="sublabel_{{ sublabel.id }}">
+        <hr>
+    <div class="flexButtons">
+        {% for label in sublabel.labels %}
+        <button onclick="changeLabel({{ label.id }})" class="labelButton" id="labelButton{{ label.id }}">{{ label.name }}</button>
+        {% endfor %}
+    </div>
+    </div>
+{% endfor %}
+{% endblock label_buttons %}
+</div>
+<br>
+<div>
+{% block task_instructions %}
+{% endblock %}
+</div>
+
+<div>
+    <h3>Comments</h3>
+    <textarea id="comments" style="width: 100%; height: 100px">{{ comments }}</textarea>
+</div>
+
+{% endblock content_left %}
+
+
+{% block content_right %}
+
+<canvas id="canvas">Failed to show images. Canvas probably not supported in the browser.</canvas>
+
+{% block task_content %}
+{% endblock %}
+
+<br>
+<button onclick=showImageInfo() title="Image information" style="width: 7%">
+    <i class="fa fa-info"></i>
+</button>
+<div id="info">
+    <strong>Dataset:</strong> {{ image_sequence.subject.dataset.name }}
+    <strong>Subject:</strong> {{ image_sequence.subject.name }}<br>
+    <strong>Filename:</strong> {{ image_sequence.format }}<br>
+</div>
+<script>
+    function showImageInfo(){
+        var e = document.getElementById("info");
+        if (e.style.display === 'block'){
+            e.style.display = 'none';}
+        else{
+            e.style.display = 'block';}
+    }
+</script>
+
+
+{% if image.metadata_set.count > 0 %}
+<h3>Image metadata</h3>
+{% for metadata in image.metadata_set.all %}
+<strong>{{ metadata.name }}:</strong> {{ metadata.value }}<br>
+{% endfor %}
+{% endif %}
+
+{% if task.description|length > 0 %}
+<h3>Task description</h3>
+
+{{ task.description|safe }}
+{% endif %}
+
+{% endblock content_right %}

--- a/classification/views.py
+++ b/classification/views.py
@@ -28,6 +28,12 @@ def label_image(request, task_id, image_id):
             print('Not found..')
             pass
 
+        classification_type = 'whole_sequence'  # TODO: How to store this??
+        if classification_type not in ('single_frame', 'whole_sequence', 'subsequence'):
+            print(f'Classification type "{classification_type}" not found.')
+        else:
+            context['classification_type'] = classification_type
+
         return render(request, 'classification/label_image.html', context)
     except common.task.NoMoreImages:
         messages.info(request, 'This task is finished, no more images to annotate.')

--- a/classification/views.py
+++ b/classification/views.py
@@ -28,11 +28,10 @@ def label_image(request, task_id, image_id):
             print('Not found..')
             pass
 
-        classification_type = 'whole_sequence'  # TODO: How to store this??
-        if classification_type not in ('single_frame', 'whole_sequence', 'subsequence'):
-            print(f'Classification type "{classification_type}" not found.')
+        if context['task'].classification_type not in ('single_frame', 'whole_sequence'):   # TODO: Add 'subsequence' when implemented
+            print(f'Classification type "{context["task"].classification_type}" not found.')
         else:
-            context['classification_type'] = classification_type
+            context['classification_type'] = context['task'].classification_type
 
         return render(request, 'classification/label_image.html', context)
     except common.task.NoMoreImages:

--- a/common/task.py
+++ b/common/task.py
@@ -24,7 +24,7 @@ def get_next_unprocessed_image(task):
     queryset = ImageSequence.objects.filter(subject__dataset__task=task) # Get all sequences for this task
     # Exclude does that are marked as finished, or not opened at all
     queryset = queryset.exclude(imageannotation__in=ImageAnnotation.objects.filter(task=task, finished=True))
-    if not task.user_frame_selection:
+    if task.user_frame_selection_valid() and not task.user_frame_selection:
         # If user cannot select their own key frames, skip those without a key frame
         queryset = queryset.exclude(imageannotation__keyframeannotation__isnull=True)
 

--- a/common/task.py
+++ b/common/task.py
@@ -256,7 +256,7 @@ def setup_task_context(request, task_id, type, image_id):
         if 'return_to_url' in request.session:
             context['return_url'] = request.session['return_to_url']
 
-    if not task.user_frame_selection:
+    if task.user_frame_selection_valid() and not task.user_frame_selection:
         # Check if image has key frames for this task
         if KeyFrameAnnotation.objects.filter(image_annotation__task=task, image_annotation__image=image).count() == 0:
             raise RuntimeError('This image sequence has no key frames. An admin must select key frames before annotating.')

--- a/common/utility.py
+++ b/common/utility.py
@@ -47,7 +47,7 @@ def get_image_as_http_response(filename, post_processing_method=''):
     return HttpResponse(buffer.getvalue(), content_type="image/png")
 
 
-def copy_image(filename, new_filename):
+def copy_image(filename, new_filename, label=None):
     _, original_extension = os.path.splitext(filename)
     _, new_extension = os.path.splitext(new_filename)
 
@@ -55,6 +55,10 @@ def copy_image(filename, new_filename):
     if original_extension.lower() == '.mhd':
         metaimage = MetaImage(filename=filename)
         if new_extension.lower() == '.mhd':
+            if label is not None:
+                # TODO: Try to add Label field
+                metaimage.set_attribute('LabelId', label.id)
+                metaimage.set_attribute('LabelName', label.name)
             metaimage.write(new_filename)
         elif new_extension.lower() == '.png':
             pil_image = metaimage.get_image()
@@ -65,6 +69,11 @@ def copy_image(filename, new_filename):
         if new_extension.lower() == '.mhd':
             pil_image = PIL.Image.open(filename)
             metaimage = MetaImage(data=np.asarray(pil_image))
+            if label is not None:
+                # TODO: Try to add Label field
+                metaimage.set_attribute('LabelId', label.id)
+                metaimage.set_attribute('LabelName', label.name)
+                pass
             metaimage.write(new_filename)
         elif new_extension.lower() == '.png':
             copyfile(filename, new_filename)

--- a/common/utility.py
+++ b/common/utility.py
@@ -56,9 +56,8 @@ def copy_image(filename, new_filename, label=None):
         metaimage = MetaImage(filename=filename)
         if new_extension.lower() == '.mhd':
             if label is not None:
-                # TODO: Try to add Label field
-                metaimage.set_attribute('LabelId', label.id)
-                metaimage.set_attribute('LabelName', label.name)
+                metaimage.set_attribute('LabelId', label['id'])
+                metaimage.set_attribute('LabelName', label['name'])
             metaimage.write(new_filename)
         elif new_extension.lower() == '.png':
             pil_image = metaimage.get_image()
@@ -70,9 +69,8 @@ def copy_image(filename, new_filename, label=None):
             pil_image = PIL.Image.open(filename)
             metaimage = MetaImage(data=np.asarray(pil_image))
             if label is not None:
-                # TODO: Try to add Label field
-                metaimage.set_attribute('LabelId', label.id)
-                metaimage.set_attribute('LabelName', label.name)
+                metaimage.set_attribute('LabelId', label['id'])
+                metaimage.set_attribute('LabelName', label['name'])
                 pass
             metaimage.write(new_filename)
         elif new_extension.lower() == '.png':

--- a/exporters/classification_exporter.py
+++ b/exporters/classification_exporter.py
@@ -71,7 +71,7 @@ class ClassificationExporter(Exporter):
         labelDict = {}
         counter = 0
         for label in labels:
-            label_file.write(label.name + '\n')
+            label_file.write(label.id + '' + label.name + '\n')  # TODO: Add label_id --> "label_id label_name"
             labelDict[label.name] = counter
             counter += 1
         label_file.close()

--- a/exporters/classification_exporter.py
+++ b/exporters/classification_exporter.py
@@ -71,7 +71,7 @@ class ClassificationExporter(Exporter):
         labelDict = {}
         counter = 0
         for label in labels:
-            label_file.write(label.id + '' + label.name + '\n')  # TODO: Add label_id --> "label_id label_name"
+            label_file.write(str(counter) + ' ' + label.name + '\n')
             labelDict[label.name] = counter
             counter += 1
         label_file.close()
@@ -90,13 +90,13 @@ class ClassificationExporter(Exporter):
             except:
                 pass
 
+            # Get image label
+            label = ImageLabel.objects.get(image=labeled_image)
+
             image_id = labeled_image.image_annotation.image_id
             new_extension = form.cleaned_data['output_image_format']
             new_filename = os.path.join(dataset_path, str(image_id) + '.' + new_extension)
-            copy_image(filepath, new_filename)
-
-            # Get image label
-            label = ImageLabel.objects.get(image=labeled_image)
+            copy_image(filepath, new_filename, label={'id': str(labelDict[label.label.name]), 'name': label.label.name})
 
             file_list.write(new_filename + ' ' + str(labelDict[label.label.name]) + '\n')
 


### PR DESCRIPTION
The classification task has not been updated in a long time and was outdated (models such as `KeyFrameAnnotation` were not working with this task type).

Here, I attempt to introduce classification types (for now, divided into single-frame and whole sequence annotation). A subsequence classification task will likely be added later.

The ClassificationExporter should also work now.